### PR TITLE
Dotty explicit nulls migration changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val scalap = project
   .in(file("src/scalap"))
   .settings(
-    scalacOptions := List("-language:Scala2", "-Yexplicit-nulls"),
+    scalacOptions := List("-language:Scala2", "-Yexplicit-nulls", "-Yjava-interop-dont-nullify-outermost"),
 
     sourceDirectory in Compile := baseDirectory.value,
     target := (baseDirectory in ThisBuild).value / "target" / thisProject.value.id,

--- a/src/scalap/scala/tools/scalap/CodeWriter.scala
+++ b/src/scalap/scala/tools/scalap/CodeWriter.scala
@@ -96,21 +96,21 @@ class CodeWriter(writer: Writer) {
 
   def println(value: String): CodeWriter = print(value).newline
 
-  def print(value: Boolean): CodeWriter = print(String.valueOf(value).nn)
+  def print(value: Boolean): CodeWriter = print(String.valueOf(value))
 
-  def print(value: Byte): CodeWriter = print(String.valueOf(value.toInt).nn)
+  def print(value: Byte): CodeWriter = print(String.valueOf(value.toInt))
 
-  def print(value: Short): CodeWriter = print(String.valueOf(value.toInt).nn)
+  def print(value: Short): CodeWriter = print(String.valueOf(value.toInt))
 
-  def print(value: Char): CodeWriter = print(String.valueOf(value).nn)
+  def print(value: Char): CodeWriter = print(String.valueOf(value))
 
-  def print(value: Int): CodeWriter = print(String.valueOf(value).nn)
+  def print(value: Int): CodeWriter = print(String.valueOf(value))
 
-  def print(value: Long): CodeWriter = print(String.valueOf(value).nn)
+  def print(value: Long): CodeWriter = print(String.valueOf(value))
 
-  def print(value: Float): CodeWriter = print(String.valueOf(value).nn)
+  def print(value: Float): CodeWriter = print(String.valueOf(value))
 
-  def print(value: Double): CodeWriter = print(String.valueOf(value).nn)
+  def print(value: Double): CodeWriter = print(String.valueOf(value))
 
   def print(value: String): CodeWriter = {
     if (align) {

--- a/src/scalap/scala/tools/scalap/CodeWriter.scala
+++ b/src/scalap/scala/tools/scalap/CodeWriter.scala
@@ -96,21 +96,21 @@ class CodeWriter(writer: Writer) {
 
   def println(value: String): CodeWriter = print(value).newline
 
-  def print(value: Boolean): CodeWriter = print(String.valueOf(value))
+  def print(value: Boolean): CodeWriter = print(String.valueOf(value).nn)
 
-  def print(value: Byte): CodeWriter = print(String.valueOf(value.toInt))
+  def print(value: Byte): CodeWriter = print(String.valueOf(value.toInt).nn)
 
-  def print(value: Short): CodeWriter = print(String.valueOf(value.toInt))
+  def print(value: Short): CodeWriter = print(String.valueOf(value.toInt).nn)
 
-  def print(value: Char): CodeWriter = print(String.valueOf(value))
+  def print(value: Char): CodeWriter = print(String.valueOf(value).nn)
 
-  def print(value: Int): CodeWriter = print(String.valueOf(value))
+  def print(value: Int): CodeWriter = print(String.valueOf(value).nn)
 
-  def print(value: Long): CodeWriter = print(String.valueOf(value))
+  def print(value: Long): CodeWriter = print(String.valueOf(value).nn)
 
-  def print(value: Float): CodeWriter = print(String.valueOf(value))
+  def print(value: Float): CodeWriter = print(String.valueOf(value).nn)
 
-  def print(value: Double): CodeWriter = print(String.valueOf(value))
+  def print(value: Double): CodeWriter = print(String.valueOf(value).nn)
 
   def print(value: String): CodeWriter = {
     if (align) {

--- a/src/scalap/scala/tools/scalap/Decode.scala
+++ b/src/scalap/scala/tools/scalap/Decode.scala
@@ -55,7 +55,7 @@ object Decode {
 
     classFile annotation SCALA_SIG_ANNOTATION map { case Annotation(_, els) =>
       val bytesElem = els find (x => constant(x.elementNameIndex) == BYTES_VALUE) orNull
-      val _bytes    = bytesElem.elementValue match { case ConstValueIndex(x) => constantWrapped(x) }
+      val _bytes    = bytesElem.nn.elementValue match { case ConstValueIndex(x) => constantWrapped(x) }
       val bytes     = _bytes.asInstanceOf[StringBytesPair].bytes
       val length    = ByteCodecs.decode(bytes)
 
@@ -103,4 +103,3 @@ object Decode {
     }
   }
 }
-

--- a/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ClassFileParser.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ClassFileParser.scala
@@ -241,7 +241,7 @@ case class ClassFileHeader(
 case class ConstantPool(len: Int) {
   val size = len - 1
 
-  private val buffer = new scala.collection.mutable.ArrayBuffer[ConstantPool => Any]
+  private val buffer = new scala.collection.mutable.ArrayBuffer[(ConstantPool => Any) | Null]
   private val values = Array.fill[Option[Any]](size)(None)
 
   def isFull = buffer.length >= size
@@ -250,7 +250,7 @@ case class ConstantPool(len: Int) {
     // Note constant pool indices are 1-based
     val i = index - 1
     values(i) getOrElse {
-      val value = buffer(i)(this)
+      val value = buffer(i).nn(this)
       buffer(i) = null
       values(i) = Some(value)
       value
@@ -262,4 +262,3 @@ case class ConstantPool(len: Int) {
     this
   }
 }
-


### PR DESCRIPTION
Changes added to compile and pass tests using the dotty-explicit-nulls-migration branch https://github.com/abeln/dotty/commit/efc4369170f90edb9e074290d20688b85dbad418. 

LOC changed: 3

**Really can be null** | 3

